### PR TITLE
課題36:例外処理実装: @ControllerAdviceによる共通例外ハンドラー

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,6 +27,7 @@ import raisetech.StudentManagement.service.StudentService;
  */
 @RestController
 @RequestMapping("/api")
+@Validated
 public class StudentController {
 
   private static final Logger logger = LoggerFactory.getLogger(StudentController.class);
@@ -76,20 +78,15 @@ public class StudentController {
   }
 
   /**
-   * 特定学生取得
+   * 特定学生取得 例外処理テスト用に修正
    */
   @GetMapping("/students/{id}")
   public ResponseEntity<StudentForm> getStudent(@PathVariable int id) {
-    try {
-      logger.info("REST API: 学生詳細取得: ID={}", id);
-      StudentForm form = service.getStudentForm(id);
-      return ResponseEntity.ok(form);
-    } catch (Exception e) {
-      logger.error("REST API: 学生詳細取得エラー: ID=" + id, e);
-      return ResponseEntity.notFound().build();  // 404 Not Found
-    }
-  }
+    logger.info("REST API: 学生詳細取得: ID={}", id);
 
+    StudentForm form = service.getStudentForm(id);
+    return ResponseEntity.ok(form);
+  }
 
   /**
    * 学生新規登録処理
@@ -148,7 +145,7 @@ public class StudentController {
       service.deleteStudent(id);
 
       ApiResponse response = new ApiResponse("success", "学生を削除しました", String.valueOf(id));
-      logger.info("REST API: 学生削除成功: ID={}" , id);
+      logger.info("REST API: 学生削除成功: ID={}", id);
       return ResponseEntity.ok(response);
 
     } catch (Exception e) {
@@ -162,6 +159,7 @@ public class StudentController {
    * API レスポンス用クラス
    */
   public static class ApiResponse {
+
     private String status;
     private String message;
     private String data;
@@ -173,8 +171,16 @@ public class StudentController {
     }
 
     // Getter methods
-    public String getStatus() { return status; }
-    public String getMessage() { return message; }
-    public String getData() { return data; }
+    public String getStatus() {
+      return status;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public String getData() {
+      return data;
+    }
   }
 }

--- a/src/main/java/raisetech/StudentManagement/controller/handler/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/StudentManagement/controller/handler/GlobalExceptionHandler.java
@@ -1,0 +1,109 @@
+package raisetech.StudentManagement.controller.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import raisetech.StudentManagement.exception.TestException;
+
+/**
+ * アプリケーション全体の共通例外ハンドラー
+ * 全てのControllerで発生した例外をここで一元的に処理する
+ */
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+  private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+  /**
+   * TestException専用グローバルハンドラー
+   * アプリケーション全体でTestExceptionが発生した場合の共通処理
+   *
+   * @param e TestException
+   * @return エラーレスポンス
+   */
+  @ExceptionHandler(TestException.class)
+  public ResponseEntity<GlobalErrorResponse> handleTestException(TestException e) {
+    logger.warn("【グローバル】TestException発生: {}", e.getMessage());
+
+    GlobalErrorResponse response = new GlobalErrorResponse(
+        "error",
+        "システムエラー",
+        e.getMessage(),
+        "TestException"
+    );
+
+    // 400 Bad Request として返す
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  /**
+   * その他の予期しない例外の共通処理
+   * RuntimeExceptionやその他の例外をキャッチする
+   *
+   * @param e Exception
+   * @return エラーレスポンス
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<GlobalErrorResponse> handleGeneralException(Exception e) {
+    logger.error("【グローバル】予期しない例外発生: {}", e.getMessage(), e);
+
+    GlobalErrorResponse response = new GlobalErrorResponse(
+        "error",
+        "内部サーバーエラーが発生しました",
+        "システム管理者にお問い合わせください",
+        e.getClass().getSimpleName()
+    );
+
+    // 500 Internal Server Error として返す
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+  }
+
+  /**
+   * IllegalArgumentException専用ハンドラー
+   * 不正な引数エラーの処理
+   *
+   * @param e IllegalArgumentException
+   * @return エラーレスポンス
+   */
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<GlobalErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+    logger.warn("【グローバル】不正な引数エラー: {}", e.getMessage());
+
+    GlobalErrorResponse response = new GlobalErrorResponse(
+        "error",
+        "入力内容に問題があります",
+        e.getMessage(),
+        "IllegalArgumentException"
+    );
+
+    // 400 Bad Request として返す
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  /**
+   * グローバルエラーレスポンス用クラス
+   * 詳細な情報を含むエラーレスポンス
+   */
+  public static class GlobalErrorResponse {
+    private String status;
+    private String message;
+    private String detail;
+    private String exceptionType;
+
+    public GlobalErrorResponse(String status, String message, String detail, String exceptionType) {
+      this.status = status;
+      this.message = message;
+      this.detail = detail;
+      this.exceptionType = exceptionType;
+    }
+
+    // Getter methods
+    public String getStatus() { return status; }
+    public String getMessage() { return message; }
+    public String getDetail() { return detail; }
+    public String getExceptionType() { return exceptionType; }
+  }
+}

--- a/src/main/java/raisetech/StudentManagement/exception/TestException.java
+++ b/src/main/java/raisetech/StudentManagement/exception/TestException.java
@@ -1,0 +1,51 @@
+package raisetech.StudentManagement.exception;
+
+/**
+ * テスト用カスタム例外クラス
+ * RuntimeExceptionを継承することで非チェック例外として扱える
+ */
+public class TestException extends RuntimeException {
+
+  /**
+   * デフォルトコンストラクタ
+   */
+  public TestException() {
+    super();
+  }
+
+  /**
+   * メッセージ付きコンストラクタ
+   * @param message エラーメッセージ
+   */
+  public TestException(String message) {
+    super(message);
+  }
+
+  /**
+   * メッセージと原因例外付きコンストラクタ
+   * @param message エラーメッセージ
+   * @param cause 原因例外
+   */
+  public TestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * 原因例外付きコンストラクタ
+   * @param cause 原因例外
+   */
+  public TestException(Throwable cause) {
+    super(cause);
+  }
+
+  /**
+   * 全パラメータ付きコンストラクタ
+   * @param message エラーメッセージ
+   * @param cause 原因例外
+   * @param enableSuppression 抑制の有効化
+   * @param writableStackTrace スタックトレースの書き込み可能性
+   */
+  public TestException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+}

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.exception.TestException;
 import raisetech.StudentManagement.form.StudentForm;
 import raisetech.StudentManagement.repository.StudentRepository;
 
@@ -85,6 +86,11 @@ public class StudentService {
    */
   @Transactional(readOnly = true)
   public StudentForm getStudentForm(int id) {
+    // テスト用：Service層での例外発生
+    if (id == 999) {
+      throw new TestException("Service層でのテストエラー：ID 999は特殊なテストIDです");
+    }
+
     logger.info("学生詳細取得開始: ID={}", id);
 
     try {
@@ -107,11 +113,12 @@ public class StudentService {
 
       logger.info("学生詳細取得完了: ID={}, コース数={}", id, courses.size());
       return form;
+
     } catch (RuntimeException e) {
       // ビジネス例外（学生未発見など）はそのまま再スロー
       throw e;
     } catch (Exception e) {
-      logger.error("学生詳細取得でシステムエラーが発生:ID={}, id, e");
+      logger.error("学生詳細取得でシステムエラーが発生: ID={}", id, e);
       throw new RuntimeException("学生情報の取得に失敗しました", e);
     }
   }


### PR DESCRIPTION
## 変更概要
Controller個別の例外処理を削除し、@ControllerAdviceによる共通例外処理を実装。

## 変更ファイル
- **追加**: `TestException.java`, `GlobalExceptionHandler.java`
- **修正**: `StudentController.java`, `StudentService.java`

## 主な変更内容
- StudentController の個別@ExceptionHandlerを削除
- GlobalExceptionHandler で TestException/RuntimeException を統一処理
- Service層にテスト用例外処理を追加（ID=999）

## 動作確認

### 1. Service層例外テスト
`GET /api/students/999` → **400 Bad Request**
<img width="1056" height="745" alt="スクリーンショット 2025-09-09 002519" src="https://github.com/user-attachments/assets/3573d4d3-d8de-49a4-8f7f-b6c2d121448c" />


### 2. 一般例外テスト
`GET /api/students/9999` → **500 Internal Server Error**
<img width="1194" height="560" alt="スクリーンショット 2025-09-09 002732" src="https://github.com/user-attachments/assets/78d15a29-afdf-4738-b789-b12c836f80e9" />


### 3. 正常処理確認
`GET /api/students/5` → **200 OK** + 学生データ返却
<img width="1230" height="797" alt="スクリーンショット 2025-09-09 002652" src="https://github.com/user-attachments/assets/c97b9c0f-8ac6-4f57-b758-24fcfaa774c3" />