### PR TITLE
課題54:fix: CD自動デプロイの再起動処理を修正

### DIFF
--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -44,6 +44,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          command_timeout: 30m
           script: |
             cd /home/ec2-user/studentmanagement/libs
             pkill -9 -f StudentManagement || true

--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -46,5 +46,8 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             cd /home/ec2-user/studentmanagement/libs
-            pkill -f StudentManagement || true
+            pkill -9 -f StudentManagement || true
+            sleep 3
             nohup java -jar StudentManagementKadai29-0.0.1-SNAPSHOT.war > app.log 2>&1 &
+            sleep 2
+            echo "Application restart completed"


### PR DESCRIPTION
## 📋 概要
GitHub ActionsでのEC2自動デプロイ時に、アプリケーション再起動処理でタイムアウトエラーが発生していたため修正しました。

## 🔧 修正内容

### JavaTest.yml
- `command_timeout: 30m` を追加してSSH接続タイムアウトを延長
- プロセス終了確認を強化

### 修正箇所
```yaml
command_timeout: 30m
```

## 🎯 期待される動作
- EC2へのデプロイが正常に完了する
- アプリケーションが自動的に再起動する
- タイムアウトエラーが発生しない
