### PR TITLE
課題54:fix: EC2上の起動スクリプトを呼び出す方式に変更

### DIFF
--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -45,16 +45,5 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            #!/bin/bash
-            cd /home/ec2-user/studentmanagement/libs
-            
-            # 既存プロセスをバックグラウンドで停止
-            (pkill -9 -f "StudentManagement" || true) &
-            sleep 2
-            
-            # 起動
-            nohup java -jar StudentManagementKadai29-0.0.1-SNAPSHOT.war > app.log 2>&1 < /dev/null &
-            disown
-            
-            sleep 3
-            echo "Deployment completed"
+            nohup /home/ec2-user/studentmanagement/restart.sh > /dev/null 2>&1 &
+            echo "Restart script triggered"


### PR DESCRIPTION
## 📋 概要
SSH接続のタイムアウト問題を解決するため、EC2上に配置した起動スクリプトを呼び出す方式に変更しました。

## 🔧 修正内容
- EC2上に `restart.sh` スクリプトを配置
- GitHub Actionsからスクリプトを呼び出すだけに変更
- SSH接続時間を最小化

## 🎯 期待される動作
- SSH接続が即座に完了する
- タイムアウトエラーが発生しない
- アプリケーションが正常に再起動する
